### PR TITLE
refactor: get local timezone identifier automatically from the computer

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ python3 app.py
 5) Los resultados se guardarán dentro de una carpeta (con nombre según la fecha y hora de ejecución) que estará dentro de la carpeta [output](output/).
 
 
-**Nota importante**: El timestamp dado por Spotify usa tiempo UTC. En este proyecto por defecto se convierte a la zona horaria de CDMX, México; puedes usar otra zona horaria ejecutando, por ejemplo, de la sig. manera:
+**Nota importante**: El timestamp dado por Spotify usa tiempo UTC. En este proyecto por defecto se calcula la zona horaria de la computadora donde se ejecuta; puedes usar otra zona horaria ejecutando, por ejemplo, de la sig. manera:
 
 ```bash
 python3 app.py --tz America/New_York

--- a/app.py
+++ b/app.py
@@ -7,9 +7,10 @@ import sys
 
 import matplotlib.pyplot as plt
 import pandas as pd
-from constants import DEFAULT_OUTPUT_PATH
 
+from constants import DEFAULT_OUTPUT_PATH
 from utils import (
+    get_local_timezone_name,
     load_streaming_history_data,
     map_int_day_to_weekday_name,
     separate_di_tuples_in_two_lists,
@@ -39,7 +40,6 @@ def setup():
 
     global logger
     logger = logging.getLogger()
-    # logger.setLevel(logging.DEBUG)
 
 
 def generate_and_save_stats(data: pd.DataFrame, output_path: str):
@@ -132,7 +132,10 @@ if __name__  == "__main__":
     setup()
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("--tz", type=str, required=False, default="America/Mexico_City")
+    parser.add_argument(
+        "--tz", type=str, required=False, default=get_local_timezone_name()
+    )
     args = parser.parse_args()
+    logger.warning(f"Using timezone: {args.tz}")
 
     run(local_timezone=args.tz)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-pandas>=1.5.2
+python-dateutil>=2.8.2
 matplotlib>=3.6.2
+pandas>=1.5.2

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, List, Optional, Tuple
 
 import pandas as pd
+from dateutil import tz
 
 from constants import DAYS_WEEK_MAP, DEFAULT_DATA_DIR
 
@@ -64,3 +65,20 @@ def write_text_lines_in_new_text_file(strings: List[str], filepath: str):
         # write all the strings to the file at once
         f.writelines(string + '\n\n' for string in strings)
 
+
+def get_local_timezone_name():
+    """Get the best available name for the local timezone.
+
+    Returns:
+        str: The name of the local timezone (e.g., "America/Los_Angeles") or
+        "America/Mexico_City" by default if it cannot be determined.
+    """
+    local_tz = tz.tzlocal()
+    if hasattr(local_tz, "_filename"):
+        tz_name = os.path.basename(local_tz._filename)
+    elif hasattr(local_tz, "_tzname"):
+        tz_name = local_tz._tzname
+    else:
+        tz_name = "America/Mexico_City"
+
+    return tz_name


### PR DESCRIPTION
## Description
- Use dateutil to compute the local timezone identifier by default when it's not passed by args.

This closes #1 